### PR TITLE
Delay when emptying queue

### DIFF
--- a/queue/ready-queue.js
+++ b/queue/ready-queue.js
@@ -99,12 +99,12 @@ module.exports = function (RED) {
 		queue.on('next',function(msg) {
 			if(!queue.isEmpty()) {
 			try{
-                setTimeout(function(){node.send(msg.job); queue.done();},delay);
-            }catch(error){node.warn("mist")}
+                setTimeout(function(){
+                    node.send(msg.job); 
+                    queue.done();
+                },delay);
+            }catch(error){}
 			}
-			node.warn(delay);
-//			node.send(msg.job) ;
-//			queue.done() ;
 		}) ;
 
 		// Log when messages are being sent from queue


### PR DESCRIPTION
Hi,
our mqtt broker is overloaded, when to many iot devices push their queues at the same time.
This is a very simple approach with default delay and configurable delay via msg.delay packet.